### PR TITLE
Dynamic FwUid retreival from config

### DIFF
--- a/main.go
+++ b/main.go
@@ -274,19 +274,6 @@ func updateAuraProfileAppConfig() {
 	} else {
 		auraContext = ""
 	}
-	/*if 0 != len(profileAppConfig.AuraConfig.Context.FwUID) {
-		//profileAppConfig.AuraConfig.Context.Dn = []
-		profileAppConfig.AuraConfig.Context.Globals = struct { SrcDoc: true }
-		profileAppConfig.AuraConfig.Context.Uad = true
-	}
-
-	// Serialize the aura config context
-	bytes, err := json.Marshal(profileAppConfig.AuraConfig.Context)
-	if err != nil {
-		log.Println(err)
-	}
-	auraContext = string(bytes)*/
-
 }
 
 // doTrailheadCallout does the callout and returns the Apex REST response from Trailhead.

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"./trailhead"
 	"github.com/gorilla/mux"
+	"github.com/meruff/go-trailhead-leaderboard-api/trailhead"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/meruff/go-trailhead-leaderboard-api/trailhead"
+	"./trailhead"
 )
 
 const (

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -35,25 +35,11 @@ type Data struct {
 	} `json:"context"`
 }
 
-type AuraConfig struct {
-	FwUid string `json:"delegateVersion"`
-}
-
-// GetAuraContext returns a JSON string containing the Aura "context" to use in the callout to Trailhead.
-func GetAuraContext(auraConfig AuraConfig) string {
-	return `{
-        "mode":"PROD",
-        "fwuid":"` + auraConfig.FwUid + `",
-        "app":"c:ProfileApp",
-        "loaded":{
-            "APPLICATION@markup://c:ProfileApp":"ZoNFIdcxHaEP9RDPdsobUQ"
-        },
-        "dn":[],
-        "globals":{
-            "srcdoc":true
-        },
-        "uad":true
-    }`
+// ProfileAppConfig represents the full configuration for the Salesforce Trailhead profile app
+type ProfileAppConfig struct {
+	AuraConfig struct {
+		Context interface{} `json:"context"`
+	} `json:"auraConfig"`
 }
 
 // GetApexAction returns a JSON string representing an Apex action to be used in the callout to Trailhead.

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -38,8 +38,26 @@ type Data struct {
 // ProfileAppConfig represents the full configuration for the Salesforce Trailhead profile app
 type ProfileAppConfig struct {
 	AuraConfig struct {
-		Context interface{} `json:"context"`
+		Context struct {
+			FwUID  string      `json:"fwuid"`
+			Loaded interface{} `json:"loaded"`
+		} `json:"context"`
 	} `json:"auraConfig"`
+}
+
+// GetAuraContext returns a JSON string containing the Aura "context" to use in the callout to Trailhead.
+func GetAuraContext(fwUID string, loaded string) string {
+	return `{
+        "mode":"PROD",
+        "fwuid":"` + fwUID + `",
+        "app":"c:ProfileApp",
+        "loaded":`+ loaded + `,
+        "dn":[],
+        "globals":{
+            "srcdoc":true
+        },
+        "uad":true
+    }`
 }
 
 // GetApexAction returns a JSON string representing an Apex action to be used in the callout to Trailhead.

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -2,8 +2,6 @@ package trailhead
 
 import "strings"
 
-const fwuid = "axnV2upVY_ZFzdo18txAEw"
-
 // Data represent a response from trailhead.salesforce.com
 type Data struct {
 	Actions []struct {
@@ -37,11 +35,15 @@ type Data struct {
 	} `json:"context"`
 }
 
+type AuraConfig struct {
+	FwUid string `json:"delegateVersion"`
+}
+
 // GetAuraContext returns a JSON string containing the Aura "context" to use in the callout to Trailhead.
-func GetAuraContext() string {
+func GetAuraContext(auraConfig AuraConfig) string {
 	return `{
         "mode":"PROD",
-        "fwuid":"` + fwuid + `",
+        "fwuid":"` + auraConfig.FwUid + `",
         "app":"c:ProfileApp",
         "loaded":{
             "APPLICATION@markup://c:ProfileApp":"ZoNFIdcxHaEP9RDPdsobUQ"


### PR DESCRIPTION
Using a global variable that will be "refreshed" in the event of a failure and the request will be retried after getting the new fwuid.

Note: if the fwuid is not retrieved successfully then it will not retry the call. should add additional logging to handle the exception case