### PR TITLE
Convert all endpoints to Trailhead's GraphQL API

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 // rankHandler returns information about a Trailblazer's rank and overall points
 func rankHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadRank", vars["id"], "", `fragment TrailheadRank on TrailheadRank {\n __typename\n title\n requiredPointsSum\n requiredBadgesCount\n imageUrl\n}\n\nfragment PublicProfile on PublicProfile {\n __typename\n trailheadStats {\n __typename\n earnedPointsSum\n earnedBadgesCount\n completedTrailCount\n rank {\n ...TrailheadRank\n }\n nextRank {\n ...TrailheadRank\n }\n }\n}\n\nquery GetTrailheadRank($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n ... on PublicProfile {\n ...PublicProfile\n }\n ... on PrivateProfile {\n __typename\n }\n }\n}\n`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadRank", vars["id"], "", trailhead.GetRankQuery()))
 
 	var trailheadRankData trailhead.Rank
 	json.Unmarshal([]byte(responseBody), &trailheadRankData)
@@ -118,7 +118,7 @@ func rankHandler(w http.ResponseWriter, r *http.Request) {
 // skillsHandler returns information about a Trailblazer's skills
 func skillsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetEarnedSkills", vars["id"], "", `fragment EarnedSkill on EarnedSkill {\n __typename\n earnedPointsSum\n id\n itemProgressEntryCount\n skill {\n __typename\n apiName\n id\n name\n}\n}\n\nquery GetEarnedSkills($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n id\n earnedSkills {\n ...EarnedSkill\n}\n}\n}\n}`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetEarnedSkills", vars["id"], "", trailhead.GetSkillsQuery()))
 
 	var trailheadSkillsData trailhead.Skills
 	json.Unmarshal([]byte(responseBody), &trailheadSkillsData)
@@ -133,7 +133,7 @@ func skillsHandler(w http.ResponseWriter, r *http.Request) {
 // certificationsHandler gets Salesforce certifications the Trailblazer has earned.
 func certificationsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetUserCertifications", vars["id"], "", `query GetUserCertifications($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n id\n ... on PublicProfile {\n credential {\n messages {\n __typename\n body\n header\n location\n image\n cta {\n __typename\n label\n url\n }\n orientation\n }\n messagesOnly\n brands {\n __typename\n id\n name\n logo\n }\n certifications {\n cta {\n __typename\n label\n url\n }\n dateCompleted\n dateExpired\n downloadLogoUrl\n logoUrl\n infoUrl\n maintenanceDueDate\n product\n publicDescription\n status {\n __typename\n title\n expired\n date\n color\n order\n }\n title\n }\n }\n }\n }\n}\n`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetUserCertifications", vars["id"], "", trailhead.GetCertificationsQuery()))
 
 	var trailheadCertificationsData trailhead.Certifications
 	json.Unmarshal([]byte(responseBody), &trailheadCertificationsData)
@@ -178,7 +178,7 @@ func badgesHandler(w http.ResponseWriter, r *http.Request) {
 		badgeRequestStruct.After = after
 	}
 
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadBadges", vars["id"], trailhead.GetBadgesFilterPayload(vars["id"], badgeRequestStruct), `fragment EarnedAward on EarnedAwardBase {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n}\n\nfragment EarnedAwardSelf on EarnedAwardSelf {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n earnedAt\n earnedPointsSum\n}\n\nfragment StatsBadgeCount on TrailheadProfileStats {\n __typename\n earnedBadgesCount\n superbadgeCount\n}\n\nfragment ProfileBadges on PublicProfile {\n __typename\n trailheadStats {\n ... on TrailheadProfileStats {\n ...StatsBadgeCount\n }\n }\n earnedAwards(first: $count, after: $after, awardType: $filter) {\n edges {\n node {\n ... on EarnedAwardBase {\n ...EarnedAward\n }\n ... on EarnedAwardSelf {\n ...EarnedAwardSelf\n }\n }\n }\n pageInfo {\n ...PageInfoBidirectional\n }\n }\n}\n\nfragment PageInfoBidirectional on PageInfo {\n __typename\n endCursor\n hasNextPage\n startCursor\n hasPreviousPage\n}\n\nquery GetTrailheadBadges($slug: String, $hasSlug: Boolean!, $count: Int = 8, $after: String = null, $filter: AwardTypeFilter = null) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n ...ProfileBadges\n }\n }\n}\n`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadBadges", vars["id"], trailhead.GetBadgesFilterPayload(vars["id"], badgeRequestStruct), trailhead.GetBadgesQuery()))
 
 	var trailheadBadgeData trailhead.Badges
 	json.Unmarshal([]byte(responseBody), &trailheadBadgeData)

--- a/main.go
+++ b/main.go
@@ -75,7 +75,11 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !strings.Contains(string(body), "var profile = ") {
-		writeErrorToBrowser(w, "Cannot find profile data on page.", 503)
+		writeErrorToBrowser(
+			w,
+			fmt.Sprintf("Cannot find profile data for %s. Does this trailblazer exist?", vars["id"]),
+			503,
+		)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -233,12 +233,6 @@ func doTrailheadCallout(payload string) (string, error) {
 	return string(body), err
 }
 
-// writeJSONToBrowser simply writes a provided string to the browser in JSON format with optional HTTP code.
-func writeJSONToBrowser(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(message))
-}
-
 // writeErrorToBrowser writes an HTTP error to the broswer in JSON.
 func writeErrorToBrowser(w http.ResponseWriter, err string, code int) {
 	w.Header().Set("Content-Type", "application/json")

--- a/main.go
+++ b/main.go
@@ -160,6 +160,9 @@ func badgesHandler(w http.ResponseWriter, r *http.Request) {
 
 	filter, after, count := vars["filter"], vars["after"], vars["count"]
 	countConvert, err := strconv.Atoi(count)
+	if err != nil {
+		log.Println("Error parsing badge count from params.")
+	}
 
 	// Create the request
 	var badgeRequestStruct = trailhead.BadgeRequest{QueryProfile: true, TrailblazerId: userID}

--- a/main.go
+++ b/main.go
@@ -189,6 +189,10 @@ func badgesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	badgeRequestBody, err := json.Marshal(badgeRequestStruct)
+	if err != nil {
+		log.Println("Error unmarshalling badgeRequestStruct")
+	}
+
 	responseBody, err := doSupabaseCallout(badgesUrl, string(badgeRequestBody))
 
 	var trailheadBadgeData trailhead.Badges
@@ -263,7 +267,7 @@ func getTrailheadID(w http.ResponseWriter, userAlias string) string {
 		// Try finding userID using TDIDUserId__c if present in response.
 		var index = strings.Index(strBody, `"TBIDUserId__c":"005`)
 
-		if -1 != index {
+		if index != -1 {
 			userID = string(strBody[index+17 : index+35])
 		}
 
@@ -271,7 +275,7 @@ func getTrailheadID(w http.ResponseWriter, userAlias string) string {
 		if !strings.HasPrefix(userID, "005") {
 			index = strings.Index(strBody, `\"Id\":\"`)
 
-			if -1 != index {
+			if index != -1 {
 				userID = string(strBody[index+9 : index+27])
 			}
 		}
@@ -280,7 +284,7 @@ func getTrailheadID(w http.ResponseWriter, userAlias string) string {
 		if !strings.HasPrefix(userID, "005") {
 			index = strings.Index(strBody, "uid: '005")
 
-			if -1 != index {
+			if index != -1 {
 				userID = string(strBody[index+6 : index+24])
 			}
 		}
@@ -302,7 +306,7 @@ func getTrailheadID(w http.ResponseWriter, userAlias string) string {
 // need to know about the FwUID
 func doTrailheadAuraCallout(apexAction string, pageURI string) trailhead.Data {
 	// If config has been retrieved, try aura call
-	if 0 != len(auraContext) {
+	if len(auraContext) != 0 {
 		var trailheadData = doTrailheadCallout(
 			`message={"actions":[` + apexAction + `]}` +
 				`&aura.context=` + auraContext + `&aura.pageURI=` + pageURI + `&aura.token="`)
@@ -319,7 +323,7 @@ func doTrailheadAuraCallout(apexAction string, pageURI string) trailhead.Data {
 	updateAuraProfileAppConfig()
 
 	// Make aura call
-	if 0 != len(auraContext) {
+	if len(auraContext) != 0 {
 		return doTrailheadCallout(
 			`message={"actions":[` + apexAction + `]}` +
 				`&aura.context=` + auraContext + `&aura.pageURI=` + pageURI + `&aura.token="`)
@@ -355,12 +359,15 @@ func updateAuraProfileAppConfig() {
 	}
 
 	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Println("Error reading response body.")
+	}
 
 	// Deserialize the entire app config
 	var profileAppConfig trailhead.ProfileAppConfig
 	json.Unmarshal(body, &profileAppConfig)
 
-	if 0 != len(profileAppConfig.AuraConfig.Context.FwUID) {
+	if len(profileAppConfig.AuraConfig.Context.FwUID) != 0 {
 		bytes, err := json.Marshal(profileAppConfig.AuraConfig.Context.Loaded)
 
 		if err != nil {
@@ -401,6 +408,10 @@ func doTrailheadCallout(messagePayload string) trailhead.Data {
 	}
 
 	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Println("Error reading response body.")
+	}
+
 	var trailheadData trailhead.Data
 	json.Unmarshal(body, &trailheadData)
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -83,10 +82,20 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 	match := re.FindStringSubmatch(string(body))
 
 	if len(match) > 1 {
-		fmt.Println("match found -", match[1])
-		writeJSONToBrowser(w, match[1])
+		var trailheadProfileData trailhead.Profile
+		json.Unmarshal([]byte(match[1]), &trailheadProfileData)
+
+		profileDataForUi := trailhead.ProfileReturn{}
+		profileDataForUi.ProfilePhotoUrl = trailheadProfileData.PhotoURL
+		profileDataForUi.ProfileUser.TBID_Role = trailheadProfileData.Role
+		profileDataForUi.ProfileUser.CompanyName = trailheadProfileData.Company.Name
+		profileDataForUi.ProfileUser.TrailblazerId = vars["id"]
+		profileDataForUi.ProfileUser.Title = trailheadProfileData.Title
+		profileDataForUi.ProfileUser.FirstName = trailheadProfileData.FirstName
+		profileDataForUi.ProfileUser.LastName = trailheadProfileData.LastName
+		profileDataForUi.ProfileUser.Id = trailheadProfileData.ID
+		encodeAndWriteToBrowser(w, profileDataForUi)
 	} else {
-		fmt.Println("match not found")
 		writeErrorToBrowser(w, `{"error":"No profile data found."}`, 503)
 	}
 }
@@ -94,7 +103,7 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 // rankHandler returns information about a Trailblazer's rank and overall points
 func rankHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadRank", vars["id"], `fragment TrailheadRank on TrailheadRank {\n __typename\n title\n requiredPointsSum\n requiredBadgesCount\n imageUrl\n}\n\nfragment PublicProfile on PublicProfile {\n __typename\n trailheadStats {\n __typename\n earnedPointsSum\n earnedBadgesCount\n completedTrailCount\n rank {\n ...TrailheadRank\n }\n nextRank {\n ...TrailheadRank\n }\n }\n}\n\nquery GetTrailheadRank($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n ... on PublicProfile {\n ...PublicProfile\n }\n ... on PrivateProfile {\n __typename\n }\n }\n}\n`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadRank", vars["id"], "", `fragment TrailheadRank on TrailheadRank {\n __typename\n title\n requiredPointsSum\n requiredBadgesCount\n imageUrl\n}\n\nfragment PublicProfile on PublicProfile {\n __typename\n trailheadStats {\n __typename\n earnedPointsSum\n earnedBadgesCount\n completedTrailCount\n rank {\n ...TrailheadRank\n }\n nextRank {\n ...TrailheadRank\n }\n }\n}\n\nquery GetTrailheadRank($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n ... on PublicProfile {\n ...PublicProfile\n }\n ... on PrivateProfile {\n __typename\n }\n }\n}\n`))
 
 	var trailheadRankData trailhead.Rank
 	json.Unmarshal([]byte(responseBody), &trailheadRankData)
@@ -109,7 +118,7 @@ func rankHandler(w http.ResponseWriter, r *http.Request) {
 // skillsHandler returns information about a Trailblazer's skills
 func skillsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetEarnedSkills", vars["id"], `fragment EarnedSkill on EarnedSkill {\n __typename\n earnedPointsSum\n id\n itemProgressEntryCount\n skill {\n __typename\n apiName\n id\n name\n}\n}\n\nquery GetEarnedSkills($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n id\n earnedSkills {\n ...EarnedSkill\n}\n}\n}\n}`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetEarnedSkills", vars["id"], "", `fragment EarnedSkill on EarnedSkill {\n __typename\n earnedPointsSum\n id\n itemProgressEntryCount\n skill {\n __typename\n apiName\n id\n name\n}\n}\n\nquery GetEarnedSkills($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n id\n earnedSkills {\n ...EarnedSkill\n}\n}\n}\n}`))
 
 	var trailheadSkillsData trailhead.Skills
 	json.Unmarshal([]byte(responseBody), &trailheadSkillsData)
@@ -124,7 +133,7 @@ func skillsHandler(w http.ResponseWriter, r *http.Request) {
 // certificationsHandler gets Salesforce certifications the Trailblazer has earned.
 func certificationsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetUserCertifications", vars["id"], `query GetUserCertifications($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n id\n ... on PublicProfile {\n credential {\n messages {\n __typename\n body\n header\n location\n image\n cta {\n __typename\n label\n url\n }\n orientation\n }\n messagesOnly\n brands {\n __typename\n id\n name\n logo\n }\n certifications {\n cta {\n __typename\n label\n url\n }\n dateCompleted\n dateExpired\n downloadLogoUrl\n logoUrl\n infoUrl\n maintenanceDueDate\n product\n publicDescription\n status {\n __typename\n title\n expired\n date\n color\n order\n }\n title\n }\n }\n }\n }\n}\n`))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetUserCertifications", vars["id"], "", `query GetUserCertifications($slug: String, $hasSlug: Boolean!) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n id\n ... on PublicProfile {\n credential {\n messages {\n __typename\n body\n header\n location\n image\n cta {\n __typename\n label\n url\n }\n orientation\n }\n messagesOnly\n brands {\n __typename\n id\n name\n logo\n }\n certifications {\n cta {\n __typename\n label\n url\n }\n dateCompleted\n dateExpired\n downloadLogoUrl\n logoUrl\n infoUrl\n maintenanceDueDate\n product\n publicDescription\n status {\n __typename\n title\n expired\n date\n color\n order\n }\n title\n }\n }\n }\n }\n}\n`))
 
 	var trailheadCertificationsData trailhead.Certifications
 	json.Unmarshal([]byte(responseBody), &trailheadCertificationsData)
@@ -169,7 +178,7 @@ func badgesHandler(w http.ResponseWriter, r *http.Request) {
 		badgeRequestStruct.After = after
 	}
 
-	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlBadgesPayload("GetTrailheadBadges", vars["id"], `fragment EarnedAward on EarnedAwardBase {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n}\n\nfragment EarnedAwardSelf on EarnedAwardSelf {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n earnedAt\n earnedPointsSum\n}\n\nfragment StatsBadgeCount on TrailheadProfileStats {\n __typename\n earnedBadgesCount\n superbadgeCount\n}\n\nfragment ProfileBadges on PublicProfile {\n __typename\n trailheadStats {\n ... on TrailheadProfileStats {\n ...StatsBadgeCount\n }\n }\n earnedAwards(first: $count, after: $after, awardType: $filter) {\n edges {\n node {\n ... on EarnedAwardBase {\n ...EarnedAward\n }\n ... on EarnedAwardSelf {\n ...EarnedAwardSelf\n }\n }\n }\n pageInfo {\n ...PageInfoBidirectional\n }\n }\n}\n\nfragment PageInfoBidirectional on PageInfo {\n __typename\n endCursor\n hasNextPage\n startCursor\n hasPreviousPage\n}\n\nquery GetTrailheadBadges($slug: String, $hasSlug: Boolean!, $count: Int = 8, $after: String = null, $filter: AwardTypeFilter = null) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n ...ProfileBadges\n }\n }\n}\n`, badgeRequestStruct))
+	responseBody, err := doTrailheadCallout(trailhead.GetGraphqlPayload("GetTrailheadBadges", vars["id"], trailhead.GetBadgesFilterPayload(vars["id"], badgeRequestStruct), `fragment EarnedAward on EarnedAwardBase {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n}\n\nfragment EarnedAwardSelf on EarnedAwardSelf {\n __typename\n id\n award {\n __typename\n id\n title\n type\n icon\n content {\n __typename\n webUrl\n description\n }\n }\n earnedAt\n earnedPointsSum\n}\n\nfragment StatsBadgeCount on TrailheadProfileStats {\n __typename\n earnedBadgesCount\n superbadgeCount\n}\n\nfragment ProfileBadges on PublicProfile {\n __typename\n trailheadStats {\n ... on TrailheadProfileStats {\n ...StatsBadgeCount\n }\n }\n earnedAwards(first: $count, after: $after, awardType: $filter) {\n edges {\n node {\n ... on EarnedAwardBase {\n ...EarnedAward\n }\n ... on EarnedAwardSelf {\n ...EarnedAwardSelf\n }\n }\n }\n pageInfo {\n ...PageInfoBidirectional\n }\n }\n}\n\nfragment PageInfoBidirectional on PageInfo {\n __typename\n endCursor\n hasNextPage\n startCursor\n hasPreviousPage\n}\n\nquery GetTrailheadBadges($slug: String, $hasSlug: Boolean!, $count: Int = 8, $after: String = null, $filter: AwardTypeFilter = null) {\n profile(slug: $slug) @include(if: $hasSlug) {\n __typename\n ... on PublicProfile {\n ...ProfileBadges\n }\n }\n}\n`))
 
 	var trailheadBadgeData trailhead.Badges
 	json.Unmarshal([]byte(responseBody), &trailheadBadgeData)

--- a/trailhead/queries.go
+++ b/trailhead/queries.go
@@ -1,0 +1,221 @@
+package trailhead
+
+// GetRankQuery returns GraphQL query for TrailheadRank
+func GetRankQuery() string {
+	return `
+		fragment TrailheadRank on TrailheadRank {
+			__typename
+			title
+			requiredPointsSum
+			requiredBadgesCount
+			imageUrl
+		}
+
+		fragment PublicProfile on PublicProfile {
+			__typename
+			trailheadStats {
+				__typename
+				earnedPointsSum
+				earnedBadgesCount
+				completedTrailCount
+				rank {
+                    ...TrailheadRank
+                }
+				nextRank {
+                    ...TrailheadRank
+                }
+			}
+		}
+
+		query GetTrailheadRank($slug: String, $hasSlug: Boolean!) {
+			profile(slug: $slug) @include(if: $hasSlug) {
+				... on PublicProfile {
+                    ...PublicProfile
+                }
+				... on PrivateProfile {
+                    __typename
+                }
+			}
+		}`
+}
+
+// GetSkillsQuery returns GraphQL query for EarnedSkill
+func GetSkillsQuery() string {
+	return `
+        fragment EarnedSkill on EarnedSkill {
+            __typename
+            earnedPointsSum
+            id
+            itemProgressEntryCount
+            skill {
+                __typename
+                apiName
+                id
+                name
+            }
+        }
+
+        query GetEarnedSkills($slug: String, $hasSlug: Boolean!) {
+            profile(slug: $slug) @include(if: $hasSlug) {
+                __typename
+                ... on PublicProfile {
+                    id
+                    earnedSkills {
+                        ...EarnedSkill
+                    }
+                }
+            }
+        }`
+}
+
+// GetCertificationsQuery returns GraphQL query for GetUserCertifications
+func GetCertificationsQuery() string {
+	return `
+        query GetUserCertifications($slug: String, $hasSlug: Boolean!) {
+            profile(slug: $slug) @include(if: $hasSlug) {
+                __typename
+                id
+                ... on PublicProfile {
+                    credential {
+                        messages {
+                            __typename
+                            body
+                            header
+                            location
+                            image
+                            cta {
+                                __typename
+                                label
+                                url
+                            }
+                            orientation
+                        }
+                        messagesOnly
+                        brands {
+                            __typename
+                            id
+                            name
+                            logo
+                        }
+                        certifications {
+                            cta {
+                            __typename
+                            label
+                            url
+                        }
+                        dateCompleted
+                        dateExpired
+                        downloadLogoUrl
+                        logoUrl
+                        infoUrl
+                        maintenanceDueDate
+                        product
+                        publicDescription
+                        status {
+                            __typename
+                            title
+                            expired
+                            date
+                            color
+                            order
+                        }
+                        title
+                    }
+                }
+            }
+        }
+    }`
+}
+
+// GetBadgesQuery returns GraphQL query for EarnedAward
+func GetBadgesQuery() string {
+	return `
+        fragment EarnedAward on EarnedAwardBase {
+            __typename
+            id
+            award {
+                __typename
+                id
+                title
+                type
+                icon
+                content {
+                    __typename
+                    webUrl
+                    description
+                }
+            }
+        }
+
+        fragment EarnedAwardSelf on EarnedAwardSelf {
+            __typename
+            id
+            award {
+                __typename
+                id
+                title
+                type
+                icon
+                content {
+                    __typename
+                    webUrl
+                    description
+                }
+            }
+            earnedAt
+            earnedPointsSum
+        }
+
+        fragment StatsBadgeCount on TrailheadProfileStats {
+        __typename
+            earnedBadgesCount
+            superbadgeCount
+        }
+
+        fragment ProfileBadges on PublicProfile {
+            __typename
+            trailheadStats {
+                ... on TrailheadProfileStats {
+                    ...StatsBadgeCount
+                }
+            }
+            earnedAwards(first: $count, after: $after, awardType: $filter) {
+                edges {
+                    node {
+                        ... on EarnedAwardBase {
+                            ...EarnedAward
+                        }
+                        ... on EarnedAwardSelf {
+                            ...EarnedAwardSelf
+                        }
+                    }
+                }
+                pageInfo {
+                    ...PageInfoBidirectional
+                }
+            }
+        }
+
+        fragment PageInfoBidirectional on PageInfo {
+            __typename
+            endCursor
+            hasNextPage
+            startCursor
+            hasPreviousPage
+        }
+
+        query GetTrailheadBadges(
+            $slug: String
+            $hasSlug: Boolean!
+            $count: Int = 8
+            $after: String = null
+            $filter: AwardTypeFilter = null
+        ) {
+            profile(slug: $slug) @include(if: $hasSlug) {
+                __typename
+                ... on PublicProfile {
+                    ...ProfileBadges
+                }
+            }
+        }`
+}

--- a/trailhead/queries.go
+++ b/trailhead/queries.go
@@ -99,32 +99,32 @@ func GetCertificationsQuery() string {
                         }
                         certifications {
                             cta {
-                            __typename
-                            label
-                            url
-                        }
-                        dateCompleted
-                        dateExpired
-                        downloadLogoUrl
-                        logoUrl
-                        infoUrl
-                        maintenanceDueDate
-                        product
-                        publicDescription
-                        status {
-                            __typename
+                                __typename
+                                label
+                                url
+                            }
+                            dateCompleted
+                            dateExpired
+                            downloadLogoUrl
+                            logoUrl
+                            infoUrl
+                            maintenanceDueDate
+                            product
+                            publicDescription
+                            status {
+                                __typename
+                                title
+                                expired
+                                date
+                                color
+                                order
+                            }
                             title
-                            expired
-                            date
-                            color
-                            order
                         }
-                        title
                     }
                 }
             }
-        }
-    }`
+        }`
 }
 
 // GetBadgesQuery returns GraphQL query for EarnedAward
@@ -167,7 +167,7 @@ func GetBadgesQuery() string {
         }
 
         fragment StatsBadgeCount on TrailheadProfileStats {
-        __typename
+            __typename
             earnedBadgesCount
             superbadgeCount
         }

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -19,7 +19,7 @@ type ProfileReturn struct {
 	}
 }
 
-// Profile represents basic trailhead data i.e. name, title, company
+// Profile represents basic trailhead data i.e. name, title, company.
 type Profile struct {
 	ID                       string `json:"id"`
 	FirstName                string `json:"firstName"`
@@ -202,7 +202,7 @@ type Badges struct {
 	} `json:"data"`
 }
 
-// BadgeRequest represents a request to the /badges endpoint. The variables to send to graphql
+// BadgeRequest represents a request to the /badges trailhead endpoint.
 type BadgeRequest struct {
 	Filter string `json:"filter"`
 	After  string `json:"after"`
@@ -229,6 +229,7 @@ func GetGraphqlPayload(operationName string, userID string, variables string, qu
 	}`
 }
 
+// GetBadgesFilterPayload returns a variables json string to be used on the GraphQL callout.
 func GetBadgesFilterPayload(userID string, badgeFilters BadgeRequest) string {
 	var afterLine, filterLine string
 

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 )
 
+// ProfileReturn represents the basic trailhead data returned via the Go API.
 type ProfileReturn struct {
 	Error           string
 	ProfilePhotoUrl string
@@ -88,6 +89,23 @@ type Skills struct {
 			} `json:"earnedSkills"`
 		} `json:"profile"`
 	} `json:"data"`
+}
+
+// CertificationsReturn represents the certification data returned via the Go API.
+type CertificationsReturn struct {
+	Error              string
+	CertificationsList []Certification
+}
+
+// Certification represents a single salesforce certification. Used in CertificationsReturn.
+type Certification struct {
+	DateExpired           string
+	DateCompleted         string
+	CertificationUrl      string
+	Description           string
+	CertificationStatus   string
+	Title                 string
+	CertificationImageUrl string
 }
 
 // Certifications represents certification records returned from trailhead.

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -60,21 +60,79 @@ type Rank struct {
 
 // Skills represents skill data returned from trailhead.
 type Skills struct {
-	Profile struct {
-		Typename     string `json:"__typename"`
-		EarnedSkills []struct {
-			Typename               string `json:"__typename"`
-			EarnedPointsSum        int    `json:"earnedPointsSum"`
-			ID                     string `json:"id"`
-			ItemProgressEntryCount int    `json:"itemProgressEntryCount"`
-			Skill                  struct {
-				Typename string `json:"__typename"`
-				APIName  string `json:"apiName"`
-				ID       string `json:"id"`
-				Name     string `json:"name"`
-			} `json:"skill"`
-		} `json:"earnedSkills"`
-	} `json:"profile"`
+	Data struct {
+		Profile struct {
+			Typename     string `json:"__typename"`
+			EarnedSkills []struct {
+				Typename               string `json:"__typename"`
+				EarnedPointsSum        int    `json:"earnedPointsSum"`
+				ID                     string `json:"id"`
+				ItemProgressEntryCount int    `json:"itemProgressEntryCount"`
+				Skill                  struct {
+					Typename string `json:"__typename"`
+					APIName  string `json:"apiName"`
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+				} `json:"skill"`
+			} `json:"earnedSkills"`
+		} `json:"profile"`
+	} `json:"data"`
+}
+
+// Certifications represents certification records returned from trailhead.
+type Certifications struct {
+	Data struct {
+		Profile struct {
+			Typename   string `json:"__typename"`
+			ID         string `json:"id"`
+			Credential struct {
+				Messages []struct {
+					Typename string `json:"__typename"`
+					Body     string `json:"body"`
+					Header   string `json:"header"`
+					Location string `json:"location"`
+					Image    string `json:"image"`
+					Cta      struct {
+						Typename string `json:"__typename"`
+						Label    string `json:"label"`
+						URL      string `json:"url"`
+					} `json:"cta"`
+					Orientation string `json:"orientation"`
+				} `json:"messages"`
+				MessagesOnly bool `json:"messagesOnly"`
+				Brands       []struct {
+					Typename string `json:"__typename"`
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					Logo     string `json:"logo"`
+				} `json:"brands"`
+				Certifications []struct {
+					Cta struct {
+						Typename string `json:"__typename"`
+						Label    string `json:"label"`
+						URL      string `json:"url"`
+					} `json:"cta"`
+					DateCompleted      string `json:"dateCompleted"`
+					DateExpired        any    `json:"dateExpired"`
+					DownloadLogoURL    string `json:"downloadLogoUrl"`
+					LogoURL            string `json:"logoUrl"`
+					InfoURL            string `json:"infoUrl"`
+					MaintenanceDueDate string `json:"maintenanceDueDate"`
+					Product            string `json:"product"`
+					PublicDescription  string `json:"publicDescription"`
+					Status             struct {
+						Typename string `json:"__typename"`
+						Title    string `json:"title"`
+						Expired  bool   `json:"expired"`
+						Date     string `json:"date"`
+						Color    string `json:"color"`
+						Order    int    `json:"order"`
+					} `json:"status"`
+					Title string `json:"title"`
+				} `json:"certifications"`
+			} `json:"credential"`
+		} `json:"profile"`
+	} `json:"data"`
 }
 
 // Badges represents skill data returned from trailhead.

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -37,23 +37,25 @@ type Data struct {
 
 // Rank represents skill data returned from trailhead.
 type Rank struct {
-	Profile struct {
-		Typename       string `json:"__typename"`
-		TrailheadStats struct {
-			Typename            string `json:"__typename"`
-			EarnedPointsSum     int    `json:"earnedPointsSum"`
-			EarnedBadgesCount   int    `json:"earnedBadgesCount"`
-			CompletedTrailCount int    `json:"completedTrailCount"`
-			Rank                struct {
+	Data struct {
+		Profile struct {
+			Typename       string `json:"__typename"`
+			TrailheadStats struct {
 				Typename            string `json:"__typename"`
-				Title               string `json:"title"`
-				RequiredPointsSum   int    `json:"requiredPointsSum"`
-				RequiredBadgesCount int    `json:"requiredBadgesCount"`
-				ImageURL            string `json:"imageUrl"`
-			} `json:"rank"`
-			NextRank interface{} `json:"nextRank"`
-		} `json:"trailheadStats"`
-	} `json:"profile"`
+				EarnedPointsSum     int    `json:"earnedPointsSum"`
+				EarnedBadgesCount   int    `json:"earnedBadgesCount"`
+				CompletedTrailCount int    `json:"completedTrailCount"`
+				Rank                struct {
+					Typename            string `json:"__typename"`
+					Title               string `json:"title"`
+					RequiredPointsSum   int    `json:"requiredPointsSum"`
+					RequiredBadgesCount int    `json:"requiredBadgesCount"`
+					ImageURL            string `json:"imageUrl"`
+				} `json:"rank"`
+				NextRank interface{} `json:"nextRank"`
+			} `json:"trailheadStats"`
+		} `json:"profile"`
+	} `json:"data"`
 }
 
 // Skills represents skill data returned from trailhead.
@@ -180,4 +182,16 @@ func GetApexAction(className string, methodName string, userID string, skip stri
 		}`
 
 	return actionString
+}
+
+// GetGraphqlPayload returns a JSON string to use in Trailhead graphql callouts.
+func GetGraphqlPayload(operationName string, userID string, query string) string {
+	return `{
+	"operationName": "` + operationName + `",
+  	"variables": {
+    	"hasSlug": true,
+    	"slug": "` + userID + `"
+  	},
+  	"query": "` + query + `"
+	}`
 }

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -4,37 +4,32 @@ import (
 	"strconv"
 )
 
-// Data represents a response from trailhead.
-type Data struct {
-	Actions []struct {
-		ID          string `json:"id"`
-		State       string `json:"state"`
-		ReturnValue struct {
-			ReturnValue struct {
-				Body                 string `json:"body"`
-				SuperbadgesResult    string `json:"superbadgesResult"`
-				CertificationsResult struct {
-					CertificationsList []struct {
-						CertificationImageURL string `json:"certificationImageUrl"`
-						CertificationStatus   string `json:"certificationStatus"`
-						CertificationURL      string `json:"certificationUrl"`
-						DateCompleted         string `json:"dateCompleted"`
-						DateExpired           string `json:"dateExpired"`
-						Description           string `json:"description"`
-						Title                 string `json:"title"`
-					} `json:"certificationsList"`
-					StatusCode    string `json:"statusCode"`
-					StatusMessage string `json:"statusMessage"`
-				} `json:"certificationsResult"`
-				IsMyTrailheadUser bool `json:"isMyTrailheadUser"`
-			} `json:"returnValue"`
-			Cacheable bool `json:"cacheable"`
-		} `json:"returnValue"`
-		Error []interface{} `json:"error"`
-	} `json:"actions"`
-	Context struct {
-		Fwuid string `json:"fwuid"`
-	} `json:"context"`
+// Profile represents basic trailhead data i.e. name, title, company
+type Profile struct {
+	ID                       string `json:"id"`
+	FirstName                string `json:"firstName"`
+	LastName                 string `json:"lastName"`
+	Username                 string `json:"username"`
+	ProfileURL               string `json:"profileUrl"`
+	BackgroundImageURL       string `json:"backgroundImageUrl"`
+	IsPublicProfile          bool   `json:"isPublicProfile"`
+	Role                     string `json:"role"`
+	Title                    string `json:"title"`
+	RelationshipToSalesforce string `json:"relationshipToSalesforce"`
+	Nickname                 string `json:"nickname"`
+	PhotoURL                 string `json:"photoUrl"`
+	Bio                      string `json:"bio"`
+	LinkedinHandle           string `json:"linkedinHandle"`
+	WebsiteURL               string `json:"websiteUrl"`
+	Company                  struct {
+		Name    string `json:"name"`
+		Size    string `json:"size"`
+		Website string `json:"website"`
+	} `json:"company"`
+	Address struct {
+		State   string `json:"state"`
+		Country string `json:"country"`
+	} `json:"address"`
 }
 
 // Rank represents skill data returned from trailhead.

--- a/trailhead/trailhead.go
+++ b/trailhead/trailhead.go
@@ -4,6 +4,20 @@ import (
 	"strconv"
 )
 
+type ProfileReturn struct {
+	Error           string
+	ProfilePhotoUrl string
+	ProfileUser     struct {
+		TBID_Role     string
+		CompanyName   string
+		TrailblazerId string
+		Title         string
+		FirstName     string
+		LastName      string
+		Id            string
+	}
+}
+
 // Profile represents basic trailhead data i.e. name, title, company
 type Profile struct {
 	ID                       string `json:"id"`
@@ -178,19 +192,26 @@ type BadgeRequest struct {
 }
 
 // GetGraphqlPayload returns a JSON string to use in Trailhead graphql callouts.
-func GetGraphqlPayload(operationName string, userID string, query string) string {
+func GetGraphqlPayload(operationName string, userID string, variables string, query string) string {
+	var variablesJsonString string
+
+	if variables != "" {
+		variablesJsonString = variables
+	} else {
+		variablesJsonString = `"variables": {
+    		"hasSlug": true,
+    		"slug": "` + userID + `"
+  		}`
+	}
+
 	return `{
-	"operationName": "` + operationName + `",
-  	"variables": {
-    	"hasSlug": true,
-    	"slug": "` + userID + `"
-  	},
-  	"query": "` + query + `"
+		"operationName": "` + operationName + `",
+  		` + variablesJsonString + `,
+  		"query": "` + query + `"
 	}`
 }
 
-// GetGraphqlPayload returns a JSON string to use in Trailhead graphql callouts.
-func GetGraphqlBadgesPayload(operationName string, userID string, query string, badgeFilters BadgeRequest) string {
+func GetBadgesFilterPayload(userID string, badgeFilters BadgeRequest) string {
 	var afterLine, filterLine string
 
 	if badgeFilters.After != "" {
@@ -205,15 +226,11 @@ func GetGraphqlBadgesPayload(operationName string, userID string, query string, 
 		filterLine = `"filter": null,`
 	}
 
-	return `{
-	"operationName": "` + operationName + `",
-  	"variables": {
+	return `"variables": {
 		"count": ` + strconv.Itoa(badgeFilters.Count) + `,
 		` + afterLine + `
 		` + filterLine + `
-    	"hasSlug": true,
-    	"slug": "` + userID + `"
-  	},
-  	"query": "` + query + `"
+		"hasSlug": true,
+		"slug": "` + userID + `"
 	}`
 }


### PR DESCRIPTION
## Description

Trailhead seems to have finished updating all their internal apis to use `https://profile.api.trailhead.com` via GraphQL. Now I can consume the endpoints via Go (which is what I should have done originally), and can remove Supabase, which wasn't great anyways. This also allows me to remove the scraping code that first tried to get a code from the profile page then used that code for subsequent callouts. 

### Changes

* Remove Supabase edge functions that were being used in favor of just using Go. 
* Update endpoint handlers to use new GraphQL apis. 
  * profile, rank, skills, certifications, badges
* Cleanup: 
  * Added more error handling. 
  * Refactor functions for new APIs.
  * Add `queries.go` to hold GraphQL queries. 